### PR TITLE
Fix incorrect comments in spot training script

### DIFF
--- a/sagemaker_spot_training_job.py
+++ b/sagemaker_spot_training_job.py
@@ -90,8 +90,8 @@ def create_spot_training_job():
         instance_count=1,
         instance_type='ml.p4d.24xlarge',  # High-performance GPU instance
         volume_size=200,
-        max_run=432000,   # Max training time (7 days)
-        max_wait=432000, # Max wait time including spot delays (14 days)
+        max_run=432000,   # Max training time (5 days)
+        max_wait=432000, # Max wait time including spot delays (5 days)
         
         # Spot instance configuration
         use_spot_instances=True,


### PR DESCRIPTION
## Summary
- correct duration comments for `max_run` and `max_wait`
- ensure file ends with a newline

## Testing
- `python3 -m py_compile sagemaker_spot_training_job.py`

------
https://chatgpt.com/codex/tasks/task_e_684002ed31008333aafa1fead7d7b3fd