### PR TITLE
Fix incorrect script names in README_SAGEMAKER

### DIFF
--- a/README_SAGEMAKER.md
+++ b/README_SAGEMAKER.md
@@ -13,8 +13,8 @@
 
 - `Dockerfile`: SageMaker 호환 Docker 이미지
 - `train_mamba.py`: 메인 훈련 스크립트
-- `train_entrypoint.sh`: SageMaker 진입점 스크립트
-- `push_to_ecr.sh`: ECR 푸시 스크립트
+- `build_and_push_ecr.ps1`: ECR 푸시 스크립트 (Windows PowerShell 예시)
+- `sagemaker_spot_training_job.py`: Spot 인스턴스용 훈련 작업 스크립트
 - `sagemaker_training_job.py`: SageMaker 훈련 작업 실행 스크립트
 - `requirements.txt`: Python 의존성
 - `accelerate_config.yaml`: Hugging Face Accelerate 설정
@@ -27,8 +27,8 @@
 # AWS CLI 설정 확인
 aws sts get-caller-identity
 
-# ECR에 이미지 빌드 및 푸시
-./push_to_ecr.sh
+# ECR에 이미지 빌드 및 푸시 (Windows PowerShell 기준)
+./build_and_push_ecr.ps1
 ```
 
 ### 2. 데이터 준비


### PR DESCRIPTION
## Summary
- correct ECR push script name
- remove reference to missing `train_entrypoint.sh`
- include spot training script in files overview
- update quick-start ECR push command

## Testing
- `grep -n "push_to_ecr.sh" -n README_SAGEMAKER.md`
- `grep -n "train_entrypoint.sh" README_SAGEMAKER.md`


------
https://chatgpt.com/codex/tasks/task_e_68402018b3b083338fb5e2c96fc53451