### PR TITLE
Fix max_run comment

### DIFF
--- a/sagemaker_training_job.py
+++ b/sagemaker_training_job.py
@@ -90,7 +90,7 @@ def create_training_job():
         instance_type='ml.p4d.24xlarge',  # High-performance GPU instance
         # instance_type='ml.g4dn.xlarge',  # Alternative for smaller training
         volume_size=200,                   # Increased EBS volume size
-        max_run=28*24*3600,                  # Max training time (24 hours)
+        max_run=28*24*3600,                  # Max training time (28 days)
         hyperparameters=hyperparameters,
         environment={
             'SAGEMAKER_PROGRAM': 'train_mamba.py',


### PR DESCRIPTION
## Summary
- fix the `max_run` comment in `sagemaker_training_job.py` to match 28-day duration

## Testing
- `pytest -q` *(fails: cannot import `MambaLMHeadModel`)*

------
https://chatgpt.com/codex/tasks/task_e_684029cbcfe483339aeda8202d5937fa