### PR TITLE
Add CONTRIBUTING instructions for testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for your interest in contributing! Before running the test suite, make sure the required packages are installed.
+
+## Installing Dependencies for Tests
+
+The unit tests rely on Hugging Face's `transformers` library and the `mamba-ssm` package. Install them with pip:
+
+```bash
+pip install transformers mamba-ssm
+```
+
+You will also need `pytest` and the libraries listed in `requirements.txt` to run the full test suite.
+
+## Running Tests
+
+After installing the dependencies, execute:
+
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- document how to run the tests
- advise installing `transformers` and `mamba-ssm`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68402b91bb3c8333aa596d3a692880f2