### PR TITLE
Update requirements for transformers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url h
 
 # 3) Install base deps
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir mamba-ssm==2.2.4 transformers==4.40.2
+RUN pip install --no-cache-dir mamba-ssm==2.2.4 transformers>=4.39.3
 
 # 4) Create necessary directories
 RUN mkdir -p /app/logs /app/checkpoints /app/configs

--- a/architecture.md
+++ b/architecture.md
@@ -23,7 +23,7 @@ conda activate mamba-env
 
 ```bash
 pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 \
-            transformers==4.39.3 tokenizers==0.15.2 \
+            transformers>=4.39.3 tokenizers==0.15.2 \
             huggingface-hub datasets sentencepiece bitsandbytes \
             mamba-ssm==2.2.4 causal-conv1d==1.5.0.post8
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch==2.2.2
 torchvision==0.17.2
 torchaudio==2.2.2
-transformers==4.40.2
+transformers>=4.39.3
 tokenizers==0.15.2
 huggingface-hub==0.23.0
 datasets==2.17.1


### PR DESCRIPTION
## Summary
- loosen transformers requirement to >=4.39.3
- note this dependency in docs and Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68402b56d9148333b575cd0c7e1b896d