### PR TITLE
Add dockerfile-parse to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyyaml==6.0.1
 safetensors==0.4.2
 einops==0.7.0
 deepspeed==0.13.1
+dockerfile-parse==2.0.1


### PR DESCRIPTION
## Summary
- include `dockerfile-parse` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403238805c8333a1ffa825bc40aa4d