### PR TITLE
Add install guidance for CPU-only environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,12 @@ Before executing `pytest`, install `transformers` and `mamba-ssm`:
 pip install transformers mamba-ssm
 ```
 
-You will also need `pytest` and the libraries listed in `requirements.txt` to run the full test suite.
+You will also need `pytest` and the libraries listed in `requirements.txt` to run the full test suite. If `nvcc` is not available on your
+system, set `MAMBA_SKIP_CUDA_BUILD=1` when installing these dependencies so the CUDA kernels are skipped:
+
+```bash
+MAMBA_SKIP_CUDA_BUILD=1 pip install -r requirements.txt
+```
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ If you want to run the test suite or make changes to this project, see
 install optional dependencies like `transformers` and `mamba-ssm` before
 running `pytest`.
 
+## Installation
+
+Install the Python packages from `requirements.txt`. If `nvcc` is not available
+on your system, set `MAMBA_SKIP_CUDA_BUILD=1` so the GPU kernels are skipped:
+
+```bash
+MAMBA_SKIP_CUDA_BUILD=1 pip install -r requirements.txt
+```
+
 ## Running Tests
 
 Install the minimal dependencies required for the unit tests:

--- a/example.env
+++ b/example.env
@@ -20,6 +20,7 @@ NUM_EPOCHS=1
 # GPU Configuration
 CUDA_VISIBLE_DEVICES=0
 NVIDIA_VISIBLE_DEVICES=all
+MAMBA_SKIP_CUDA_BUILD=1 # set to 1 to avoid building GPU kernels
 
 # Paths
 CHECKPOINT_DIR=checkpoints


### PR DESCRIPTION
## Summary
- document how to skip CUDA build when installing requirements
- add same info for contributors running tests
- provide a variable example in `example.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403547aba48333af577e047c7d5027