### PR TITLE
Update tests to skip when dockerfile-parse not installed

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -37,7 +37,11 @@ def test_compile_sagemaker_launcher():
 
 def test_parse_dockerfile():
     """Basic syntax check for the Dockerfile using dockerfile-parse"""
-    from dockerfile_parse import DockerfileParser
+    import pytest
+    try:
+        from dockerfile_parse import DockerfileParser
+    except ImportError as exc:  # pragma: no cover - skip if unavailable
+        pytest.skip(f"dockerfile_parse unavailable: {exc}")
     dockerfile_path = Path(__file__).resolve().parents[1] / "Dockerfile"
     parser = DockerfileParser(str(dockerfile_path))
     assert parser.baseimage is not None


### PR DESCRIPTION
## Summary
- allow `test_parse_dockerfile` to skip when `dockerfile-parse` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840354d8b6883338f76f9fc7fd0cf03