### PR TITLE
Update testing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,18 @@ Thank you for your interest in contributing to this project!
 ## Running Tests
 
 The unit tests require a few optional libraries that are not installed by default.
-Before executing `pytest`, install `transformers` and `mamba-ssm`:
+Before executing `pytest`, install `transformers`, `mamba-ssm`, and `dockerfile-parse`:
 
 ```bash
-pip install transformers mamba-ssm
+pip install transformers mamba-ssm dockerfile-parse
 ```
 
-You will also need `pytest` and the libraries listed in `requirements.txt` to run the full test suite.
+You will also need `pytest` and the libraries listed in `requirements.txt` to run the full test suite.  The easiest
+way is to install everything at once:
 
-## Running Tests
+```bash
+MAMBA_SKIP_CUDA_BUILD=1 pip install -r requirements.txt
+```
 
 After installing the dependencies, execute:
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,14 @@ running `pytest`.
 
 ## Running Tests
 
-Install the minimal dependencies required for the unit tests:
+Install the dependencies used by the unit tests:
 
 ```bash
-pip install transformers mamba-ssm
+MAMBA_SKIP_CUDA_BUILD=1 pip install -r requirements.txt
+pip install pytest
 ```
 
+This installs packages like `transformers`, `mamba-ssm` and `dockerfile-parse`.
 Then run the test suite with `pytest`:
 
 ```bash


### PR DESCRIPTION
## Summary
- document dockerfile-parse as a test dependency
- show how to install all requirements via `MAMBA_SKIP_CUDA_BUILD=1 pip install -r requirements.txt`
- update README instructions for running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840354b01888333a3b8ba19e850db26